### PR TITLE
Adopt Semantic Versioning

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+
+
+## Semantic versioning
+
+The DynamicMenuPortlet project uses [Semantic Versioning](http://semver.org/).
+
+> Summary
+
+> Given a version number MAJOR.MINOR.PATCH, increment the:
+
+> MAJOR version when you make incompatible API changes,
+> MINOR version when you add functionality in a backwards-compatible manner, and
+> PATCH version when you make backwards-compatible bug fixes.

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
     <groupId>edu.wisc.portlet</groupId>
     <artifactId>DynamicMenuPortlet</artifactId>
     <packaging>war</packaging>
+    <!-- Use Semantic Versioning.  See CONTRIBUTING.md . -->
     <version>1.0.1-SNAPSHOT</version>
     <name>Dynamic Menu Portlet</name>
     <description>Portlet that generates a UI based on the groups the user is in.</description>

--- a/src/main/java/edu/wisc/my/portlets/dmp/beans/MenuItem.java
+++ b/src/main/java/edu/wisc/my/portlets/dmp/beans/MenuItem.java
@@ -47,7 +47,6 @@ import org.apache.commons.lang.builder.ToStringStyle;
  * Represents an item displayed on the menu portlet.
  * 
  * @author sschwartz
- * @version $Id: MenuItem.java,v 1.1 2008/09/29 00:53:51 dalquist Exp $
  */
 public class MenuItem {
     private String name = null;

--- a/src/main/java/edu/wisc/my/portlets/dmp/beans/MenuItem.java
+++ b/src/main/java/edu/wisc/my/portlets/dmp/beans/MenuItem.java
@@ -47,6 +47,7 @@ import org.apache.commons.lang.builder.ToStringStyle;
  * Represents an item displayed on the menu portlet.
  * 
  * @author sschwartz
+ * @since 1.0
  */
 public class MenuItem {
     private String name = null;

--- a/src/main/java/edu/wisc/my/portlets/dmp/dao/CachingMenuDao.java
+++ b/src/main/java/edu/wisc/my/portlets/dmp/dao/CachingMenuDao.java
@@ -13,7 +13,6 @@ import edu.wisc.my.portlets.dmp.beans.MenuItem;
 
 /**
  * @author Eric Dalquist
- * @version $Revision: 1.1 $
  */
 public class CachingMenuDao implements MenuDao {
     private MenuDao menuDao;

--- a/src/main/java/edu/wisc/my/portlets/dmp/dao/CachingMenuDao.java
+++ b/src/main/java/edu/wisc/my/portlets/dmp/dao/CachingMenuDao.java
@@ -13,6 +13,7 @@ import edu.wisc.my.portlets.dmp.beans.MenuItem;
 
 /**
  * @author Eric Dalquist
+ * @since 1.0
  */
 public class CachingMenuDao implements MenuDao {
     private MenuDao menuDao;

--- a/src/main/java/edu/wisc/my/portlets/dmp/dao/GroupsDao.java
+++ b/src/main/java/edu/wisc/my/portlets/dmp/dao/GroupsDao.java
@@ -9,7 +9,6 @@ package edu.wisc.my.portlets.dmp.dao;
  * Provides a method for getting group memebership information for a user.
  * 
  * @author Eric Dalquist <a href="mailto:eric.dalquist@doit.wisc.edu">eric.dalquist@doit.wisc.edu</a>
- * @version $Revision: 1.1 $
  */
 public interface GroupsDao {
     /**

--- a/src/main/java/edu/wisc/my/portlets/dmp/dao/GroupsDao.java
+++ b/src/main/java/edu/wisc/my/portlets/dmp/dao/GroupsDao.java
@@ -9,6 +9,7 @@ package edu.wisc.my.portlets.dmp.dao;
  * Provides a method for getting group memebership information for a user.
  * 
  * @author Eric Dalquist <a href="mailto:eric.dalquist@doit.wisc.edu">eric.dalquist@doit.wisc.edu</a>
+ * @since 1.0
  */
 public interface GroupsDao {
     /**

--- a/src/main/java/edu/wisc/my/portlets/dmp/dao/MenuDao.java
+++ b/src/main/java/edu/wisc/my/portlets/dmp/dao/MenuDao.java
@@ -45,7 +45,6 @@ import edu.wisc.my.portlets.dmp.beans.MenuItem;
  * retrieving menus.
  * 
  * @author sschwartz
- * @version $Id: MenuDao.java,v 1.1 2008/09/29 00:53:51 dalquist Exp $
  */
 public interface MenuDao {
 

--- a/src/main/java/edu/wisc/my/portlets/dmp/dao/MenuDao.java
+++ b/src/main/java/edu/wisc/my/portlets/dmp/dao/MenuDao.java
@@ -45,6 +45,7 @@ import edu.wisc.my.portlets.dmp.beans.MenuItem;
  * retrieving menus.
  * 
  * @author sschwartz
+ * @since 1.0
  */
 public interface MenuDao {
 

--- a/src/main/java/edu/wisc/my/portlets/dmp/dao/filter/FilteringMenuDao.java
+++ b/src/main/java/edu/wisc/my/portlets/dmp/dao/filter/FilteringMenuDao.java
@@ -10,7 +10,6 @@ import edu.wisc.my.portlets.dmp.dao.MenuDao;
 
 /**
  * @author Eric Dalquist
- * @version $Revision: 1.1 $
  */
 public class FilteringMenuDao implements MenuDao {
     private MenuDao delegateMenuDao;

--- a/src/main/java/edu/wisc/my/portlets/dmp/dao/filter/FilteringMenuDao.java
+++ b/src/main/java/edu/wisc/my/portlets/dmp/dao/filter/FilteringMenuDao.java
@@ -10,6 +10,7 @@ import edu.wisc.my.portlets.dmp.dao.MenuDao;
 
 /**
  * @author Eric Dalquist
+ * @since 1.0
  */
 public class FilteringMenuDao implements MenuDao {
     private MenuDao delegateMenuDao;

--- a/src/main/java/edu/wisc/my/portlets/dmp/dao/filter/FilteringMenuItem.java
+++ b/src/main/java/edu/wisc/my/portlets/dmp/dao/filter/FilteringMenuItem.java
@@ -18,6 +18,7 @@ import edu.wisc.my.portlets.dmp.beans.MenuItem;
 
 /**
  * @author Eric Dalquist
+ * @since 1.0
  */
 public class FilteringMenuItem extends MenuItem {
     private final MenuItem filteredMenuItem;

--- a/src/main/java/edu/wisc/my/portlets/dmp/dao/filter/FilteringMenuItem.java
+++ b/src/main/java/edu/wisc/my/portlets/dmp/dao/filter/FilteringMenuItem.java
@@ -18,7 +18,6 @@ import edu.wisc.my.portlets.dmp.beans.MenuItem;
 
 /**
  * @author Eric Dalquist
- * @version $Revision: 1.2 $
  */
 public class FilteringMenuItem extends MenuItem {
     private final MenuItem filteredMenuItem;

--- a/src/main/java/edu/wisc/my/portlets/dmp/dao/gap/UPortalGroupsDao.java
+++ b/src/main/java/edu/wisc/my/portlets/dmp/dao/gap/UPortalGroupsDao.java
@@ -24,6 +24,7 @@ import edu.wisc.my.portlets.dmp.dao.GroupsDao;
  * Backs the GroupsDao interface with the uPortal Groups service.
  * 
  * @author Eric Dalquist <a href="mailto:eric.dalquist@doit.wisc.edu">eric.dalquist@doit.wisc.edu</a>
+ * @since 1.0
  */
 public class UPortalGroupsDao implements GroupsDao {
     private final Log LOG = LogFactory.getLog(UPortalGroupsDao.class);

--- a/src/main/java/edu/wisc/my/portlets/dmp/dao/gap/UPortalGroupsDao.java
+++ b/src/main/java/edu/wisc/my/portlets/dmp/dao/gap/UPortalGroupsDao.java
@@ -24,7 +24,6 @@ import edu.wisc.my.portlets.dmp.dao.GroupsDao;
  * Backs the GroupsDao interface with the uPortal Groups service.
  * 
  * @author Eric Dalquist <a href="mailto:eric.dalquist@doit.wisc.edu">eric.dalquist@doit.wisc.edu</a>
- * @version $Revision: 1.1 $
  */
 public class UPortalGroupsDao implements GroupsDao {
     private final Log LOG = LogFactory.getLog(UPortalGroupsDao.class);

--- a/src/main/java/edu/wisc/my/portlets/dmp/dao/jdbc/JdbcMenuDao.java
+++ b/src/main/java/edu/wisc/my/portlets/dmp/dao/jdbc/JdbcMenuDao.java
@@ -61,6 +61,7 @@ import edu.wisc.my.portlets.dmp.dao.MenuDao;
 
 /**
  * @author Eric Dalquist <a href="mailto:eric.dalquist@doit.wisc.edu">eric.dalquist@doit.wisc.edu</a>
+ * @since 1.0
  */
 public class JdbcMenuDao extends JdbcDaoSupport implements MenuDao {
     private DataFieldMaxValueIncrementer menuIdIncrementer;

--- a/src/main/java/edu/wisc/my/portlets/dmp/dao/jdbc/JdbcMenuDao.java
+++ b/src/main/java/edu/wisc/my/portlets/dmp/dao/jdbc/JdbcMenuDao.java
@@ -61,7 +61,6 @@ import edu.wisc.my.portlets.dmp.dao.MenuDao;
 
 /**
  * @author Eric Dalquist <a href="mailto:eric.dalquist@doit.wisc.edu">eric.dalquist@doit.wisc.edu</a>
- * @version $Revision: 1.1 $
  */
 public class JdbcMenuDao extends JdbcDaoSupport implements MenuDao {
     private DataFieldMaxValueIncrementer menuIdIncrementer;

--- a/src/main/java/edu/wisc/my/portlets/dmp/tools/MenuItemGeneratingHandler.java
+++ b/src/main/java/edu/wisc/my/portlets/dmp/tools/MenuItemGeneratingHandler.java
@@ -55,7 +55,6 @@ import edu.wisc.my.portlets.dmp.beans.MenuItem;
  * Monitors SAX events and generates DMP menus.
  * 
  * @author Eric Dalquist <a href="mailto:eric.dalquist@doit.wisc.edu">eric.dalquist@doit.wisc.edu</a>
- * @version $Id: MenuItemGeneratingHandler.java,v 1.1 2008/09/29 00:53:50 dalquist Exp $
  */
 public class MenuItemGeneratingHandler implements ContentHandler {
     //Locations

--- a/src/main/java/edu/wisc/my/portlets/dmp/tools/MenuItemGeneratingHandler.java
+++ b/src/main/java/edu/wisc/my/portlets/dmp/tools/MenuItemGeneratingHandler.java
@@ -55,6 +55,7 @@ import edu.wisc.my.portlets.dmp.beans.MenuItem;
  * Monitors SAX events and generates DMP menus.
  * 
  * @author Eric Dalquist <a href="mailto:eric.dalquist@doit.wisc.edu">eric.dalquist@doit.wisc.edu</a>
+ * @since 1.0
  */
 public class MenuItemGeneratingHandler implements ContentHandler {
     //Locations

--- a/src/main/java/edu/wisc/my/portlets/dmp/tools/XmlLocationStack.java
+++ b/src/main/java/edu/wisc/my/portlets/dmp/tools/XmlLocationStack.java
@@ -41,7 +41,6 @@ package edu.wisc.my.portlets.dmp.tools;
  * location in the XML document. 
  * 
  * @author Eric Dalquist <a href="mailto:eric.dalquist@doit.wisc.edu">eric.dalquist@doit.wisc.edu</a>
- * @version $Revision: 1.1 $
  */
 public class XmlLocationStack {
     private final StringBuffer location = new StringBuffer();

--- a/src/main/java/edu/wisc/my/portlets/dmp/tools/XmlLocationStack.java
+++ b/src/main/java/edu/wisc/my/portlets/dmp/tools/XmlLocationStack.java
@@ -41,6 +41,7 @@ package edu.wisc.my.portlets.dmp.tools;
  * location in the XML document. 
  * 
  * @author Eric Dalquist <a href="mailto:eric.dalquist@doit.wisc.edu">eric.dalquist@doit.wisc.edu</a>
+ * @since 1.0
  */
 public class XmlLocationStack {
     private final StringBuffer location = new StringBuffer();

--- a/src/main/java/edu/wisc/my/portlets/dmp/tools/XmlMenuPublisher.java
+++ b/src/main/java/edu/wisc/my/portlets/dmp/tools/XmlMenuPublisher.java
@@ -65,7 +65,6 @@ import edu.wisc.my.portlets.dmp.dao.MenuDao;
  * the database.
  * 
  * @author Eric Dalquist <a href="mailto:eric.dalquist@doit.wisc.edu">eric.dalquist@doit.wisc.edu</a>
- * @version $Id: XmlMenuPublisher.java,v 1.2 2010/01/27 19:11:45 dalquist Exp $
  */
 public class XmlMenuPublisher {
     private static final Log LOG = LogFactory.getLog(XmlMenuPublisher.class);

--- a/src/main/java/edu/wisc/my/portlets/dmp/tools/XmlMenuPublisher.java
+++ b/src/main/java/edu/wisc/my/portlets/dmp/tools/XmlMenuPublisher.java
@@ -65,6 +65,7 @@ import edu.wisc.my.portlets.dmp.dao.MenuDao;
  * the database.
  * 
  * @author Eric Dalquist <a href="mailto:eric.dalquist@doit.wisc.edu">eric.dalquist@doit.wisc.edu</a>
+ * @since 1.0
  */
 public class XmlMenuPublisher {
     private static final Log LOG = LogFactory.getLog(XmlMenuPublisher.class);

--- a/src/main/java/edu/wisc/my/portlets/dmp/tools/XmlMenuPublisherRunner.java
+++ b/src/main/java/edu/wisc/my/portlets/dmp/tools/XmlMenuPublisherRunner.java
@@ -53,7 +53,6 @@ import org.apache.commons.cli.PosixParser;
  * class to publish menus to the database.
  * 
  * @author Eric Dalquist <a href="mailto:eric.dalquist@doit.wisc.edu">eric.dalquist@doit.wisc.edu</a>
- * @version $Id: XmlMenuPublisherRunner.java,v 1.1 2008/09/29 00:53:50 dalquist Exp $
  */
 public class XmlMenuPublisherRunner {
     private static final String XML_FILE_OPT = "f";

--- a/src/main/java/edu/wisc/my/portlets/dmp/tools/XmlMenuPublisherRunner.java
+++ b/src/main/java/edu/wisc/my/portlets/dmp/tools/XmlMenuPublisherRunner.java
@@ -53,6 +53,7 @@ import org.apache.commons.cli.PosixParser;
  * class to publish menus to the database.
  * 
  * @author Eric Dalquist <a href="mailto:eric.dalquist@doit.wisc.edu">eric.dalquist@doit.wisc.edu</a>
+ * @since 1.0
  */
 public class XmlMenuPublisherRunner {
     private static final String XML_FILE_OPT = "f";

--- a/src/main/java/edu/wisc/my/portlets/dmp/web/CachingXsltView.java
+++ b/src/main/java/edu/wisc/my/portlets/dmp/web/CachingXsltView.java
@@ -25,7 +25,6 @@ import org.springframework.web.servlet.view.xslt.AbstractXsltView;
  * property.
  * 
  * @author Eric Dalquist
- * @version $Revision: 1.1 $
  */
 public class CachingXsltView extends AbstractXsltView {
     private Map<Serializable, String> xsltResultCache;

--- a/src/main/java/edu/wisc/my/portlets/dmp/web/CachingXsltView.java
+++ b/src/main/java/edu/wisc/my/portlets/dmp/web/CachingXsltView.java
@@ -25,6 +25,7 @@ import org.springframework.web.servlet.view.xslt.AbstractXsltView;
  * property.
  * 
  * @author Eric Dalquist
+ * @since 1.0
  */
 public class CachingXsltView extends AbstractXsltView {
     private Map<Serializable, String> xsltResultCache;

--- a/src/main/java/edu/wisc/my/portlets/dmp/web/MenuItemInputSource.java
+++ b/src/main/java/edu/wisc/my/portlets/dmp/web/MenuItemInputSource.java
@@ -50,6 +50,7 @@ import edu.wisc.my.portlets.dmp.beans.MenuItem;
  * MenuItem structure to the MenuItemXmlReader
  * 
  * @author Eric Dalquist <a href="mailto:eric.dalquist@doit.wisc.edu">eric.dalquist@doit.wisc.edu</a>
+ * @since 1.0
  */
 public class MenuItemInputSource extends InputSource {
     private final Map<String, MenuItem> menus;

--- a/src/main/java/edu/wisc/my/portlets/dmp/web/MenuItemInputSource.java
+++ b/src/main/java/edu/wisc/my/portlets/dmp/web/MenuItemInputSource.java
@@ -50,7 +50,6 @@ import edu.wisc.my.portlets.dmp.beans.MenuItem;
  * MenuItem structure to the MenuItemXmlReader
  * 
  * @author Eric Dalquist <a href="mailto:eric.dalquist@doit.wisc.edu">eric.dalquist@doit.wisc.edu</a>
- * @version $Id: MenuItemInputSource.java,v 1.1 2008/09/29 00:53:51 dalquist Exp $
  */
 public class MenuItemInputSource extends InputSource {
     private final Map<String, MenuItem> menus;

--- a/src/main/java/edu/wisc/my/portlets/dmp/web/MenuItemXmlReader.java
+++ b/src/main/java/edu/wisc/my/portlets/dmp/web/MenuItemXmlReader.java
@@ -61,7 +61,6 @@ import edu.wisc.my.portlets.dmp.beans.MenuItem;
  * well formed XML representing the structure using SAX events.
  * 
  * @author Eric Dalquist <a href="mailto:eric.dalquist@doit.wisc.edu">eric.dalquist@doit.wisc.edu</a>
- * @version $Id: MenuItemXmlReader.java,v 1.1 2008/09/29 00:53:51 dalquist Exp $
  */
 public class MenuItemXmlReader implements XMLReader, Locator {
     private static final String ELEMENT_MENUS = "menus";

--- a/src/main/java/edu/wisc/my/portlets/dmp/web/MenuItemXmlReader.java
+++ b/src/main/java/edu/wisc/my/portlets/dmp/web/MenuItemXmlReader.java
@@ -61,6 +61,7 @@ import edu.wisc.my.portlets.dmp.beans.MenuItem;
  * well formed XML representing the structure using SAX events.
  * 
  * @author Eric Dalquist <a href="mailto:eric.dalquist@doit.wisc.edu">eric.dalquist@doit.wisc.edu</a>
+ * @since 1.0
  */
 public class MenuItemXmlReader implements XMLReader, Locator {
     private static final String ELEMENT_MENUS = "menus";

--- a/src/main/java/edu/wisc/my/portlets/dmp/web/MenuXsltView.java
+++ b/src/main/java/edu/wisc/my/portlets/dmp/web/MenuXsltView.java
@@ -20,7 +20,6 @@ import edu.wisc.my.portlets.dmp.beans.MenuItem;
  * Creates a {@link Source} from a root MenuItem and menu name provided in the model.
  * 
  * @author Eric Dalquist <a href="mailto:eric.dalquist@doit.wisc.edu">eric.dalquist@doit.wisc.edu</a>
- * @version $Revision: 1.1 $
  */
 public class MenuXsltView extends CachingXsltView {
     

--- a/src/main/java/edu/wisc/my/portlets/dmp/web/MenuXsltView.java
+++ b/src/main/java/edu/wisc/my/portlets/dmp/web/MenuXsltView.java
@@ -20,6 +20,7 @@ import edu.wisc.my.portlets.dmp.beans.MenuItem;
  * Creates a {@link Source} from a root MenuItem and menu name provided in the model.
  * 
  * @author Eric Dalquist <a href="mailto:eric.dalquist@doit.wisc.edu">eric.dalquist@doit.wisc.edu</a>
+ * @since 1.0
  */
 public class MenuXsltView extends CachingXsltView {
     

--- a/src/main/java/edu/wisc/my/portlets/dmp/web/ViewMenuController.java
+++ b/src/main/java/edu/wisc/my/portlets/dmp/web/ViewMenuController.java
@@ -29,7 +29,6 @@ import edu.wisc.my.portlets.dmp.dao.MenuDao;
  * user is a member of.
  * 
  * @author Eric Dalquist <a href="mailto:eric.dalquist@doit.wisc.edu">eric.dalquist@doit.wisc.edu</a>
- * @version $Revision: 1.3 $
  */
 public class ViewMenuController extends AbstractController {
     /**

--- a/src/main/java/edu/wisc/my/portlets/dmp/web/ViewMenuController.java
+++ b/src/main/java/edu/wisc/my/portlets/dmp/web/ViewMenuController.java
@@ -29,6 +29,7 @@ import edu.wisc.my.portlets.dmp.dao.MenuDao;
  * user is a member of.
  * 
  * @author Eric Dalquist <a href="mailto:eric.dalquist@doit.wisc.edu">eric.dalquist@doit.wisc.edu</a>
+ * @since 1.0
  */
 public class ViewMenuController extends AbstractController {
     /**

--- a/src/test/java/edu/wisc/my/portlets/dmp/beans/MenuItemTest.java
+++ b/src/test/java/edu/wisc/my/portlets/dmp/beans/MenuItemTest.java
@@ -39,7 +39,6 @@ import junit.framework.TestCase;
 
 /**
  * @author Eric Dalquist <a href="mailto:eric.dalquist@doit.wisc.edu">eric.dalquist@doit.wisc.edu</a>
- * @version $Revision: 1.1 $
  */
 public class MenuItemTest extends TestCase {
     

--- a/src/test/java/edu/wisc/my/portlets/dmp/beans/MenuItemTest.java
+++ b/src/test/java/edu/wisc/my/portlets/dmp/beans/MenuItemTest.java
@@ -39,6 +39,7 @@ import junit.framework.TestCase;
 
 /**
  * @author Eric Dalquist <a href="mailto:eric.dalquist@doit.wisc.edu">eric.dalquist@doit.wisc.edu</a>
+ * @since 1.0
  */
 public class MenuItemTest extends TestCase {
     

--- a/src/test/java/edu/wisc/my/portlets/dmp/dao/jdbc/JdbcMenuDaoTest.java
+++ b/src/test/java/edu/wisc/my/portlets/dmp/dao/jdbc/JdbcMenuDaoTest.java
@@ -55,6 +55,7 @@ import edu.wisc.my.portlets.dmp.beans.MenuItem;
 
 /**
  * @author sschwartz
+ * @since 1.0
  */
 public class JdbcMenuDaoTest extends TestCase {
     private DataSource testDataSource;

--- a/src/test/java/edu/wisc/my/portlets/dmp/dao/jdbc/JdbcMenuDaoTest.java
+++ b/src/test/java/edu/wisc/my/portlets/dmp/dao/jdbc/JdbcMenuDaoTest.java
@@ -55,7 +55,6 @@ import edu.wisc.my.portlets.dmp.beans.MenuItem;
 
 /**
  * @author sschwartz
- * @version $Id: JdbcMenuDaoTest.java,v 1.1 2008/09/29 00:53:51 dalquist Exp $
  */
 public class JdbcMenuDaoTest extends TestCase {
     private DataSource testDataSource;

--- a/src/test/java/org/jasig/portal/rdbm/InMemoryDataFieldMaxValueIncrementer.java
+++ b/src/test/java/org/jasig/portal/rdbm/InMemoryDataFieldMaxValueIncrementer.java
@@ -9,6 +9,7 @@ import org.springframework.jdbc.support.incrementer.AbstractDataFieldMaxValueInc
 
 /**
  * @author Eric Dalquist <a href="mailto:eric.dalquist@doit.wisc.edu">eric.dalquist@doit.wisc.edu</a>
+ * @since 1.0
  */
 public class InMemoryDataFieldMaxValueIncrementer extends AbstractDataFieldMaxValueIncrementer {
     private long key;

--- a/src/test/java/org/jasig/portal/rdbm/InMemoryDataFieldMaxValueIncrementer.java
+++ b/src/test/java/org/jasig/portal/rdbm/InMemoryDataFieldMaxValueIncrementer.java
@@ -9,7 +9,6 @@ import org.springframework.jdbc.support.incrementer.AbstractDataFieldMaxValueInc
 
 /**
  * @author Eric Dalquist <a href="mailto:eric.dalquist@doit.wisc.edu">eric.dalquist@doit.wisc.edu</a>
- * @version $Revision: 1.1 $
  */
 public class InMemoryDataFieldMaxValueIncrementer extends AbstractDataFieldMaxValueIncrementer {
     private long key;

--- a/src/test/java/org/jasig/portal/rdbm/TransientDatasource.java
+++ b/src/test/java/org/jasig/portal/rdbm/TransientDatasource.java
@@ -19,7 +19,6 @@ import org.apache.commons.dbcp.BasicDataSource;
  * A DataSource implementation backed by an in-memory HSQLDb instance,
  * suitable for implementing testcases for DataSource-consuming DAO impls.
  * @author andrew.petro@yale.edu
- * @version $Revision: 1.3 $ $Date: 2013/05/13 19:55:51 $
  */
 public class TransientDatasource implements DataSource {
     

--- a/src/test/java/org/jasig/portal/rdbm/TransientDatasource.java
+++ b/src/test/java/org/jasig/portal/rdbm/TransientDatasource.java
@@ -19,6 +19,7 @@ import org.apache.commons.dbcp.BasicDataSource;
  * A DataSource implementation backed by an in-memory HSQLDb instance,
  * suitable for implementing testcases for DataSource-consuming DAO impls.
  * @author andrew.petro@yale.edu
+ * @since 1.0
  */
 public class TransientDatasource implements DataSource {
     

--- a/src/test/java/org/jasig/portal/rdbm/TransientDatasourceTest.java
+++ b/src/test/java/org/jasig/portal/rdbm/TransientDatasourceTest.java
@@ -15,6 +15,7 @@ import junit.framework.TestCase;
 /**
  * Testcase for HsqlDatasource
  * @author andrew.petro@yale.edu
+ * @since 1.0
  */
 public class TransientDatasourceTest extends TestCase {
 

--- a/src/test/java/org/jasig/portal/rdbm/TransientDatasourceTest.java
+++ b/src/test/java/org/jasig/portal/rdbm/TransientDatasourceTest.java
@@ -15,7 +15,6 @@ import junit.framework.TestCase;
 /**
  * Testcase for HsqlDatasource
  * @author andrew.petro@yale.edu
- * @version $Revision: 1.1 $ $Date: 2008/09/29 00:53:51 $
  */
 public class TransientDatasourceTest extends TestCase {
 


### PR DESCRIPTION
Semantic versioning is a good idea, and since DynamicMenuPortlet is at `1.0` with no substantive changes beyond that tag, it's not too late to cleanly adopt it.

Adopts Semantic Versioning by documenting this in a `CONTRIBUTING.md` and a reminder comment in the `pom.xml`.

Zaps the at best confusing `@version` JavaDoc tags. Looks like they're static legacy stuff from a prior version control system, and that their versions do not align with the project version number.

Adds `@since 1.0` JavaDoc tags to the classes that exist as of the `1.0` version, which is to say all of them.  This sets the stage to use `@since` to document APIs that come into the codebase post-1.0, if any.
