### PR TITLE
Bugfix : FilteringMenuDao API adherence when user not authorized for root menu item

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>DynamicMenuPortlet</artifactId>
     <packaging>war</packaging>
     <!-- Use Semantic Versioning.  See CONTRIBUTING.md . -->
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <name>Dynamic Menu Portlet</name>
     <description>Portlet that generates a UI based on the groups the user is in.</description>
 

--- a/src/main/java/edu/wisc/my/portlets/dmp/beans/MenuItem.java
+++ b/src/main/java/edu/wisc/my/portlets/dmp/beans/MenuItem.java
@@ -58,7 +58,44 @@ public class MenuItem {
     private String target = null;
     private WindowState[] displayStates = new WindowState[0];
     
-    
+    /**
+     * Returns true if userGroups is not null and contains at least one group name that matches a
+     * group to which this MenuItem is granted.  Returns false otherwise.
+     * @param userGroups potentially null groups held by a user
+     * @return true if the user has a matching group authorizing access to this menu item, false
+     * otherwise
+     *
+     * @since 1.1
+     */
+    public boolean hasMatchingGroup(final String[] userGroups) {
+
+        if (null == userGroups) {
+            return false;
+        }
+
+        if (null == this.groups) {
+            return false;
+        }
+
+        for (final String authorizedGroup : groups /* groups authorized to see menu item */) {
+
+            if (null != authorizedGroup) {
+
+                for (final String grantedGroup /* group the user has */ : userGroups) {
+
+                    if (null != grantedGroup && authorizedGroup.equals(grantedGroup)) {
+
+                        // found a match! user is authorized to see the root menu
+                        return true;
+                    }
+                }
+            }
+        }
+
+        // did not find a match; user is not authorized to see menu item.
+        return false;
+    }
+
     
     /**
      * An ordered list of children this portlet has. May not be null. May be

--- a/src/main/java/edu/wisc/my/portlets/dmp/dao/filter/FilteringMenuDao.java
+++ b/src/main/java/edu/wisc/my/portlets/dmp/dao/filter/FilteringMenuDao.java
@@ -36,40 +36,14 @@ public class FilteringMenuDao implements MenuDao {
     public MenuItem getMenu(String menuName, String[] userGroups) {
         final MenuItem menuItem = this.delegateMenuDao.getMenu(menuName);
 
-        // this group checking logic cries out for refactoring
-
         // the userGroups must include at least one group to which the root menu item is granted
         // or else getMenu() should return null as specified in the API.
 
-        if (null == userGroups) {
-            return null;
+        if (menuItem.hasMatchingGroup(userGroups)) {
+            // user is authorized to see the root menu,
+            // so return the not-null filtering-wrapped menu item.
+            return new FilteringMenuItem(menuItem, userGroups);
         }
-
-        final String[] groupsAuthorizedToSeeRootMenuItem = menuItem.getGroups();
-
-        if (null == groupsAuthorizedToSeeRootMenuItem) {
-            return null;
-        }
-
-
-        for (final String authorizedGroup : groupsAuthorizedToSeeRootMenuItem) {
-
-            if (null != authorizedGroup) {
-                for (final String grantedGroup : userGroups) {
-
-                    if ( null != grantedGroup && authorizedGroup.equals(grantedGroup)) {
-
-                        // found a match! user is authorized to see the root menu,
-                        // so return the not-null filtering-wrapped menu item.
-                        return new FilteringMenuItem(menuItem, userGroups);
-
-                    }
-
-                }
-            }
-
-        }
-
 
         // user groups not among those authorized to see root menu item, so return null as per
         // interface definition of this getMenu() method.

--- a/src/main/java/edu/wisc/my/portlets/dmp/dao/filter/FilteringMenuDao.java
+++ b/src/main/java/edu/wisc/my/portlets/dmp/dao/filter/FilteringMenuDao.java
@@ -8,6 +8,8 @@ package edu.wisc.my.portlets.dmp.dao.filter;
 import edu.wisc.my.portlets.dmp.beans.MenuItem;
 import edu.wisc.my.portlets.dmp.dao.MenuDao;
 
+import java.util.Set;
+
 /**
  * @author Eric Dalquist
  * @since 1.0
@@ -33,7 +35,45 @@ public class FilteringMenuDao implements MenuDao {
      */
     public MenuItem getMenu(String menuName, String[] userGroups) {
         final MenuItem menuItem = this.delegateMenuDao.getMenu(menuName);
-        return new FilteringMenuItem(menuItem, userGroups);
+
+        // this group checking logic cries out for refactoring
+
+        // the userGroups must include at least one group to which the root menu item is granted
+        // or else getMenu() should return null as specified in the API.
+
+        if (null == userGroups) {
+            return null;
+        }
+
+        final String[] groupsAuthorizedToSeeRootMenuItem = menuItem.getGroups();
+
+        if (null == groupsAuthorizedToSeeRootMenuItem) {
+            return null;
+        }
+
+
+        for (final String authorizedGroup : groupsAuthorizedToSeeRootMenuItem) {
+
+            if (null != authorizedGroup) {
+                for (final String grantedGroup : userGroups) {
+
+                    if ( null != grantedGroup && authorizedGroup.equals(grantedGroup)) {
+
+                        // found a match! user is authorized to see the root menu,
+                        // so return the not-null filtering-wrapped menu item.
+                        return new FilteringMenuItem(menuItem, userGroups);
+
+                    }
+
+                }
+            }
+
+        }
+
+
+        // user groups not among those authorized to see root menu item, so return null as per
+        // interface definition of this getMenu() method.
+        return null;
     }
 
     

--- a/src/main/java/edu/wisc/my/portlets/dmp/dao/filter/FilteringMenuDao.java
+++ b/src/main/java/edu/wisc/my/portlets/dmp/dao/filter/FilteringMenuDao.java
@@ -36,6 +36,10 @@ public class FilteringMenuDao implements MenuDao {
     public MenuItem getMenu(String menuName, String[] userGroups) {
         final MenuItem menuItem = this.delegateMenuDao.getMenu(menuName);
 
+        if (null == menuItem) {
+            return null;
+        }
+
         // the userGroups must include at least one group to which the root menu item is granted
         // or else getMenu() should return null as specified in the API.
 

--- a/src/main/java/edu/wisc/my/portlets/dmp/dao/memory/InMemoryMenuDao.java
+++ b/src/main/java/edu/wisc/my/portlets/dmp/dao/memory/InMemoryMenuDao.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package edu.wisc.my.portlets.dmp.dao.memory;
+
+import edu.wisc.my.portlets.dmp.beans.MenuItem;
+import edu.wisc.my.portlets.dmp.dao.MenuDao;
+//import edu.wisc.my.portlets.dmp.dao.filter.FilteringMenuItem;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * An in-memory implementation of MenuDao.
+ *
+ * @since 1.1
+ */
+public final class InMemoryMenuDao
+    implements MenuDao {
+
+    private Map<String, MenuItem> menus = new HashMap<String, MenuItem>();
+
+    @Override
+    public String[] getPublishedMenuNames() {
+        return this.menus.keySet().toArray(new String[0]);
+    }
+
+    @Override
+    public MenuItem getMenu(final String menuName) {
+        return this.menus.get(menuName);
+    }
+
+    @Override
+    public MenuItem getMenu(final String menuName, final String[] userGroups) {
+        throw new UnsupportedOperationException(
+            "Getting menu filtered by groups not yet supported");
+        //return new FilteringMenuItem(this.menus.get(menuName), userGroups);
+    }
+
+    @Override
+    public void storeMenu(final String menuName, final MenuItem rootItem) {
+        this.menus.put(menuName, rootItem);
+    }
+
+    @Override
+    public void deleteMenu(final String menuName) {
+        this.menus.remove(menuName);
+    }
+}

--- a/src/test/java/edu/wisc/my/portlets/dmp/beans/MenuItemTest.java
+++ b/src/test/java/edu/wisc/my/portlets/dmp/beans/MenuItemTest.java
@@ -65,6 +65,59 @@ public class MenuItemTest extends TestCase {
             //This is what we want!
         }
     }
+
+    /**
+     * Test that hasMatchingGroup() correctly returns true when presented groups have a match.
+     */
+    public void testHasMatchingGroup() {
+
+        final MenuItem menuItem = new MenuItem();
+        menuItem.setGroups( new String[] {"privilegedFew", "huddledMasses"});
+
+        final String[] userGroups = new String[] { "privilegedFew", "someIrrelevantGroup"};
+
+        assertTrue(menuItem.hasMatchingGroup(userGroups));
+
+    }
+
+    /**
+     * Test that hasMatchingGroup() correctly returns false when presented groups do not match.
+     */
+    public void testDoesNotHaveMatchingGroup() {
+
+        final MenuItem menuItem = new MenuItem();
+        menuItem.setGroups( new String[] {"privilegedFew", "huddledMasses"});
+
+        final String[] userGroups = new String[] { "unprivileged"};
+
+        assertFalse(menuItem.hasMatchingGroup(userGroups));
+
+    }
+
+    /**
+     * Test that returns false when the menu item is not granted to any groups.
+     */
+    public void testDoesNotHaveMatchingGroupWhenItemGroupsAreNull() {
+
+        final MenuItem menuItem = new MenuItem();
+
+        final String[] userGroups = new String[] { "privilegedFew"};
+
+        assertFalse(menuItem.hasMatchingGroup(userGroups));
+
+    }
+
+    /**
+     * Test that returns false when the user has null groups.
+     */
+    public void testDoesNotHaveMatchingGroupWhenUserGroupsAreNull() {
+
+        final MenuItem menuItem = new MenuItem();
+        menuItem.setGroups( new String[] {"privilegedFew", "huddledMasses"});
+
+        assertFalse(menuItem.hasMatchingGroup(null));
+
+    }
     
     
 }

--- a/src/test/java/edu/wisc/my/portlets/dmp/dao/filter/FilteringMenuDaoTest.java
+++ b/src/test/java/edu/wisc/my/portlets/dmp/dao/filter/FilteringMenuDaoTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package edu.wisc.my.portlets.dmp.dao.filter;
+
+import edu.wisc.my.portlets.dmp.beans.MenuItem;
+import edu.wisc.my.portlets.dmp.dao.memory.InMemoryMenuDao;
+import junit.framework.TestCase;
+import org.junit.Test;
+
+/**
+ * Test cases for the filtering menu DAO.
+ */
+public class FilteringMenuDaoTest extends TestCase {
+
+    /**
+     * Test that the filtering DAO returns null when the user is not in any of the groups that
+     * can see a root menu item.
+     */
+    @Test
+    public void testFiltersToNullWhenNotInGroupsForWholeMenu() {
+
+        final MenuItem rootMenuItem = new MenuItem();
+        rootMenuItem.setGroups(new String[] {"a_group_the_user_is_not_in"});
+
+        final InMemoryMenuDao underlyingDao = new InMemoryMenuDao();
+        underlyingDao.storeMenu("aMenu", rootMenuItem);
+
+        final FilteringMenuDao filteringWrapper = new FilteringMenuDao();
+        filteringWrapper.setDelegateMenuDao(underlyingDao);
+
+        assertNull(filteringWrapper.getMenu("aMenu",
+            new String[] {"groups", "not_including", "the_one_group", "granted_this_menu"} ));
+
+    }
+
+    /**
+     * Test that the filtering DAO passes through a root menu granted to a group the user is in.
+     */
+    @Test
+    public void testAuthorizedMenuPassesThroughFilter() {
+
+        final MenuItem rootMenuItem = new MenuItem();
+        rootMenuItem.setGroups(new String[] {"yes_in_this_group", "some_other_irrelevant_group"});
+
+        final InMemoryMenuDao underlyingDao = new InMemoryMenuDao();
+        underlyingDao.storeMenu("aMenu", rootMenuItem);
+
+        final FilteringMenuDao filteringWrapper = new FilteringMenuDao();
+        filteringWrapper.setDelegateMenuDao(underlyingDao);
+
+        final MenuItem actual =  filteringWrapper.getMenu("aMenu",
+            new String[] {"yes_in_this_group", "in_other_groups_too_but_they_do_not_matter"});
+
+        // this assertion is goofy (rather than assertEquals( expected, actual) because of
+        // a weirdness in the MenuItem implementation of equals() , which rabbit hole the test
+        // author did not choose to immediately pursue.
+        assertTrue( actual.equals(rootMenuItem));
+
+    }
+
+}

--- a/src/test/java/edu/wisc/my/portlets/dmp/dao/filter/FilteringMenuDaoTest.java
+++ b/src/test/java/edu/wisc/my/portlets/dmp/dao/filter/FilteringMenuDaoTest.java
@@ -75,4 +75,20 @@ public class FilteringMenuDaoTest extends TestCase {
 
     }
 
+    /**
+     * Test that the filtering DAO passes through a null (representing menu not found).
+     */
+    public void testNotFoundMenuReturnsNull() {
+
+        final InMemoryMenuDao underlyingDao = new InMemoryMenuDao();
+
+        final FilteringMenuDao filteringWrapper = new FilteringMenuDao();
+        filteringWrapper.setDelegateMenuDao(underlyingDao);
+
+        assertNull( filteringWrapper.getMenu("does_not_exist") );
+        assertNull( filteringWrapper.getMenu("still_does_not_exist",
+            new String[] { "no", "matter", "what", "groups", "I", "have" }) );
+
+    }
+
 }

--- a/src/test/java/edu/wisc/my/portlets/dmp/dao/memory/InMemoryMenuDaoTest.java
+++ b/src/test/java/edu/wisc/my/portlets/dmp/dao/memory/InMemoryMenuDaoTest.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package edu.wisc.my.portlets.dmp.dao.memory;
+
+import edu.wisc.my.portlets.dmp.beans.MenuItem;
+import junit.framework.TestCase;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertArrayEquals;
+
+/**
+ * Unit tests for the in-memory implementation of the menu DAO.
+ *
+ * Written in the JUnit3 extends TestCase style to match other tests in this project.
+ *
+ * @since 1.1
+ */
+public class InMemoryMenuDaoTest extends TestCase {
+
+    /**
+     * When there are no stored menus,
+     * the DAO should give an empty array
+     * when asked for the names of menus.
+     */
+    @Test
+    public void testReportsNoMenuNames() {
+
+        final InMemoryMenuDao inMemoryMenuDao = new InMemoryMenuDao();
+        assertArrayEquals(new String[] {}, inMemoryMenuDao.getPublishedMenuNames());
+
+    }
+
+    /**
+     * When there are stored menus,
+     * the DAO should accurately report the names of those menus.
+     */
+    @Test
+    public void testReportsMenuNames() {
+        final InMemoryMenuDao inMemoryMenuDao = new InMemoryMenuDao();
+
+        final MenuItem thingOne = new MenuItem();
+        final MenuItem thingTwo = new MenuItem();
+
+        inMemoryMenuDao.storeMenu("thingOne", thingOne);
+        inMemoryMenuDao.storeMenu("thingTwo", thingTwo);
+
+        final String[] actualMenuNames = inMemoryMenuDao.getPublishedMenuNames();
+        Arrays.sort(actualMenuNames);
+
+        final String[] expectedMenuNames = { "thingOne", "thingTwo"};
+        Arrays.sort(expectedMenuNames);
+
+        assertArrayEquals(expectedMenuNames, actualMenuNames);
+
+    }
+
+    /**
+     * When the requested menu does not exist,
+     * returns null.
+     */
+    @Test
+    public void testReturnsNullOnGetUnknownMenu() {
+
+        final InMemoryMenuDao inMemoryMenuDao = new InMemoryMenuDao();
+
+        final MenuItem thingOne = new MenuItem();
+        final MenuItem thingTwo = new MenuItem();
+
+        inMemoryMenuDao.storeMenu("thingOne", thingOne);
+        inMemoryMenuDao.storeMenu("thingTwo", thingTwo);
+
+        assertNull(inMemoryMenuDao.getMenu("does-not-exist"));
+
+    }
+
+    /**
+     * When the requested menu does exist,
+     * returns it.
+     */
+    @Test
+    public void testReturnsMenu() {
+
+        final InMemoryMenuDao inMemoryMenuDao = new InMemoryMenuDao();
+
+        final MenuItem thingOne = new MenuItem();
+        final MenuItem thingTwo = new MenuItem();
+
+        thingOne.setName("Thing One");
+        thingOne.setUrl("https://www.google.com");
+        thingOne.setTarget("_blank");
+        thingOne.setGroups( new String[] { "HuddledMasses", "PrivilegedFew" } );
+        thingOne.setDescription("An example menu item.");
+
+        inMemoryMenuDao.storeMenu("thingOne", thingOne);
+        inMemoryMenuDao.storeMenu("thingTwo", thingTwo);
+
+        assertEquals(thingOne, inMemoryMenuDao.getMenu("thingOne"));
+
+    }
+
+    /**
+     * When the user has a group granting access to the requested menu item,
+     * returns the menu item.
+     *
+     * This is a naive test of the group filtering (when paired with the test demonstrating
+     * that it filter away when the group does not match).  These tests are sufficient to verify
+     * that the in memory DAO is doing something about filtering; the actual filtering behavior is
+     * implemented via FilteringMenuItem, which should have its own comprehensive unit tests.
+     */
+
+    /*
+    @Test
+    public void testReturnsFilteredMenuWhenGroupMatches() {
+
+        final InMemoryMenuDao inMemoryMenuDao = new InMemoryMenuDao();
+
+        final MenuItem thingOne = new MenuItem();
+        final MenuItem thingTwo = new MenuItem();
+
+        thingOne.setName("Thing One");
+        thingOne.setUrl("https://www.google.com");
+        thingOne.setTarget("_blank");
+        thingOne.setGroups( new String[] { "HuddledMasses", "PrivilegedFew" } );
+        thingOne.setDescription("An example menu item.");
+
+        inMemoryMenuDao.storeMenu("thingOne", thingOne);
+        inMemoryMenuDao.storeMenu("thingTwo", thingTwo);
+
+        // the user has a matching group (HuddledMasses).
+        final String[] matchingGroups = new String[] { "HuddledMasses", "Proletariat"};
+
+        assertEquals(thingOne, inMemoryMenuDao.getMenu("thingOne", matchingGroups));
+
+    }
+    */
+
+    /**
+     * When the user has no group granting access to the requested menu item,
+     * returns null.
+     *
+     * This is a naive test of the group filtering sufficient to verify
+     * that the in memory DAO is doing something about filtering; the actual filtering behavior is
+     * implemented via FilteringMenuItem, which should have its own comprehensive unit tests for
+     * deep filtering behavior within the tree.
+     */
+
+    /*
+    @Test
+    public void testFiltersAwayMenuWhenGroupDoesNotMatch() {
+
+        final InMemoryMenuDao inMemoryMenuDao = new InMemoryMenuDao();
+
+        final MenuItem thingOne = new MenuItem();
+        final MenuItem thingTwo = new MenuItem();
+
+        thingOne.setName("Thing One");
+        thingOne.setUrl("https://www.google.com");
+        thingOne.setTarget("_blank");
+        thingOne.setGroups(new String[] {"PrivilegedFew", "Superusers"});
+        thingOne.setDescription("An example menu item.");
+
+        inMemoryMenuDao.storeMenu("thingOne", thingOne);
+        inMemoryMenuDao.storeMenu("thingTwo", thingTwo);
+
+        // the user has no matching group
+        final String[] matchingGroups = new String[] { "HuddledMasses", "Proletariat"};
+
+        assertNull(inMemoryMenuDao.getMenu("thingOne", matchingGroups));
+
+    }
+    */
+
+}


### PR DESCRIPTION
The API is specified as

```
    /**
     * Gets the root MenuItem for a named menu and set of groups. Will return null if no
     * menu exists for the name or if the root item cannot be displayed for any of the
     * passed groups
     *     
```

but the `FilteringMenuDao` implementation did not return null in either of the not-authorized or not-existing cases.

With this fix, it does, verified by unit tests.

The refactored solution adds a convenience method to `MenuItem` to determine whether the presented groups are sufficient to access the item.  This seems appropriate and object-oriented, since `MenuItem` already knows what groups are authorized to access it.

Bumps the `MINOR` version per semantic versioning, since adds a method to `MenuItem`.

Discovered that `MenuItem` `equals()` is likely over-specified, but did not choose to address that issue.

All of this is in support of implementing an in-memory menu item DAO, which is partially implemented in this changeset to support the unit tests.
